### PR TITLE
Update enigma.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You must install OpenWebif from your enigma2 image.
   - Picon from current channel
   - Supports authentication and multiple receivers
   - Sending notifications to the box (timeout and type of message can be selected)
-    
+  - * NEW: Load sources from selected bouquet
 # Tested with OpenWebif versions:
   - 0.2.7
   - 1.3.0
@@ -62,6 +62,46 @@ notify:
     username: root
     password: !secret enigma_password
 ```
+# Load sources from selected bouquet
+Find your bouquet's <e2servicereference> name http://box.ip/web/getallservices
+
+```
+<e2servicelistrecursive>
+<e2service>
+<e2servicereference>
+1:7:1:0:0:0:0:0:0:0:FROM BOUQUET "userbouquet.favourites.tv" ORDER BY bouquet
+</e2servicereference>
+<e2servicename>Favourites (TV)</e2servicename>
+</e2service>
+<e2bouquet>
+<e2servicereference>
+1:7:1:0:0:0:0:0:0:0:FROM BOUQUET "userbouquet.upcd__digi_hu__1w_.tv" ORDER BY bouquet
+</e2servicereference>
+<e2servicename>01.0W - UPC+DIGI MIX</e2servicename>
+<e2servicelist>
+<e2service>
+<e2servicereference>1:0:1:FC8:D:1:E062E2F:0:0:0:</e2servicereference>
+<e2servicename>M1 HD</e2servicename>
+</e2service>
+...
+```
+In my case, I want to use 01.0W - UPC+DIGI MIX bouquet, so I need string from <e2servicereference> above: 
+
+```1:7:1:0:0:0:0:0:0:0:FROM BOUQUET "userbouquet.upcd__digi_hu__1w_.tv" ORDER BY bouquet```
+
+``` python
+media_player:
+- platform: enigma
+    host: 192.168.1.50
+    port: 80
+    name: Gigablue
+    icon: mdi:satellite-variant
+    timeout: 20
+    username: root
+    password: !secret enigma_password
+    bouquet: '1:7:1:0:0:0:0:0:0:0:FROM BOUQUET "userbouquet.upcd__digi_hu__1w_.tv" ORDER BY bouquet'
+```
+
 # Screenshots
 ![Channel example 1](../master/screenshots/1.png)
 ![Channel example 2](../master/screenshots/2.png)

--- a/media_player/enigma.py
+++ b/media_player/enigma.py
@@ -189,7 +189,7 @@ class EnigmaDevice(MediaPlayerDevice):
 
             eventtitle = 'N/A'
             """ If we got a valid reference, check the title of the event and the picon url """
-            if reference != 'N/A':
+            if reference != 'N/A' and not reference.startswith('1:0:0:0:0:0:0:0:0:0:'):
                 xml = self.request_call('/web/epgservicenow?sRef=' + reference)
                 soup = BeautifulSoup(xml, 'html.parser')
                 eventtitle = soup.e2eventtitle.renderContents().decode('UTF8')

--- a/media_player/enigma.py
+++ b/media_player/enigma.py
@@ -46,7 +46,6 @@ DEFAULT_USERNAME = 'root'
 DEFAULT_PASSWORD = None
 
 CONF_BOUQUET = 'bouquet'
-DEFAULT_BOUQUET = None
 
 SUPPORT_ENIGMA = SUPPORT_VOLUME_SET | SUPPORT_VOLUME_MUTE | \
                  SUPPORT_TURN_ON | SUPPORT_TURN_OFF | \
@@ -62,7 +61,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PASSWORD, default=DEFAULT_PASSWORD): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
     vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.socket_timeout,
-    vol.Optional(CONF_BOUQUET, default=DEFAULT_BOUQUET ): cv.string,
+    vol.Optional(CONF_BOUQUET): cv.string,
 })
 
 @asyncio.coroutine
@@ -128,7 +127,7 @@ class EnigmaDevice(MediaPlayerDevice):
 
     def load_sources(self):
 
-        if not (self._bouquet is None):
+        if self._bouquet:
 
             """Load user set bouquet."""
 


### PR DESCRIPTION
Fix crash for playing local movies.

**/web/subservices**
```
<e2servicelist>
<e2service>
<e2servicereference>
1:0:0:0:0:0:0:0:0:0:/media/net/UBUNTU/movie/20181023 2055 - Slager TV - Drága családom - Az Emílio Família.ts
</e2servicereference>
<e2servicename>Drága családom - Az Emílio Família</e2servicename>
</e2service>
</e2servicelist>
```

While playing movies, service reference is 1:0:0:0:0:0:0:0:0:0: and no EPG available.

Without this fix plugin crashes:

```
2018-10-23 22:10:32 ERROR (MainThread) [homeassistant.components.media_player] enigma: Error on device update!
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/homeassistant/helpers/entity_platform.py", line 251, in _async_add_entity
    await entity.async_device_update(warning=False)
  File "/usr/local/lib/python3.6/site-packages/homeassistant/helpers/entity.py", line 349, in async_device_update
    await self.hass.async_add_job(self.update)
  File "/usr/local/lib/python3.6/concurrent/futures/thread.py", line 56, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/local/lib/python3.6/site-packages/homeassistant/util/__init__.py", line 324, in wrapper
    result = method(*args, **kwargs)
  File "/config/custom_components/media_player/enigma.py", line 193, in update
    xml = self.request_call('/web/epgservicenow?sRef=' + reference)
  File "/config/custom_components/media_player/enigma.py", line 152, in request_call
    return self._opener.open(uri, timeout=self._timeout).read().decode('UTF8')
  File "/usr/local/lib/python3.6/urllib/request.py", line 526, in open
    response = self._open(req, data)
  File "/usr/local/lib/python3.6/urllib/request.py", line 544, in _open
    '_open', req)
  File "/usr/local/lib/python3.6/urllib/request.py", line 504, in _call_chain
    result = func(*args)
  File "/usr/local/lib/python3.6/urllib/request.py", line 1346, in http_open
    return self.do_open(http.client.HTTPConnection, req)
  File "/usr/local/lib/python3.6/urllib/request.py", line 1318, in do_open
    encode_chunked=req.has_header('Transfer-encoding'))
  File "/usr/local/lib/python3.6/http/client.py", line 1239, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/usr/local/lib/python3.6/http/client.py", line 1250, in _send_request
    self.putrequest(method, url, **skips)
  File "/usr/local/lib/python3.6/http/client.py", line 1117, in putrequest
    self._output(request.encode('ascii'))
UnicodeEncodeError: 'ascii' codec can't encode character '\xe1' in position 102: ordinal not in range(128)
```