### PR TITLE
Update manifest.json do not hard-pin old versions

### DIFF
--- a/enigma/manifest.json
+++ b/enigma/manifest.json
@@ -7,5 +7,5 @@
   "dependencies": [],
   "after_dependencies": [],
   "codeowners": ["@cinzas"],
-  "requirements": ["beautifulsoup4==4.6.3"]
+  "requirements": ["beautifulsoup4>=4.6.3"]
 }


### PR DESCRIPTION
can confirm it runs good with "current" beautifulsoup-4.9.3, which is required by more than one core integrations.